### PR TITLE
add debug logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function Discovery (opts) {
   function ondhtpeer (peer, infoHash, via) {
     if (self.destroyed) return
     var id = self._unhash[infoHash.toString('hex')]
-    debug('chan=%s dht discovery peer=%s:%s via=%s:%s', prettyHash(id), peer.host, peer.port, via.address, via.port)
+    debug('chan=%s dht discovery peer=%s:%s via=%s:%s', prettyHash(id), peer.host, peer.port)
     if (id) self.emit('peer', id, peer, 'dht')
   }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "bittorrent-dht": "^7.2.1",
     "debug": "^2.3.2",
     "dns-discovery": "^5.3.4",
+    "pretty-hash": "^1.0.0",
     "thunky": "^0.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "bittorrent-dht": "^7.2.1",
+    "debug": "^2.3.2",
     "dns-discovery": "^5.3.4",
     "thunky": "^0.1.0"
   },


### PR DESCRIPTION
This is part of an overall effort to add debug output to all of the dat network stack.

To test, run `DEBUG=discovery-channel npm test`.

Double-check my output in case it's wrong or incomplete.