### PR TITLE
add cb and test to .join

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,12 @@ Returns a new instance. `opts` is optional and can have the following properties
 
 By default hashes are re-announced around every 10 min on the dht and 1 min using dns. Set `dht.interval` or `dns.interval` to change these.
 
-### `channel.join(id, [port])`
+### `channel.join(id, [port], [cb])`
 
 Perform a lookup across all networks for `id`. `id` can be a buffer or a string.
 Specify `port` if you want to announce that you share `id` as well.
+
+If you specify `cb`, it will be called **when the first round** of discovery has completed. But only on the first round.
 
 ### `channel.leave(id, [port])`
 

--- a/test.js
+++ b/test.js
@@ -54,3 +54,14 @@ test('find each other', function (t) {
     channel2.destroy()
   }
 })
+
+test('join cb gets called', function (t) {
+  var id = crypto.randomBytes(32)
+  var channel1 = DC()
+  channel1.join(id, 1337, function (err) {
+    t.ifErr(err)
+    t.ok('called cb')
+    channel1.destroy()
+    t.end()
+  })
+})


### PR DESCRIPTION
this is so we can know when the initial round of queries to discovery backends has completed, so we can fail early in the CLI

### `channel.join(id, [port], [cb])`

If you specify `cb`, it will be called **when the first round** of discovery has completed. But only on the first round.
