### PR TITLE
Resolve "Callback was already called." when `pending` >= 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ Discovery.prototype.join = function (id, port, opts, cb) {
   var firstQueryDone = false
   function queryDone (err) {
     if (firstQueryDone) return
-    if (--pending <= 0) firstQueryDone = true
+    if (--pending <= 1) firstQueryDone = true
     self.emit('query-done', true)
     cb(err)
   }


### PR DESCRIPTION
I am experiencing a strange error with [dat-boi](https://github.com/garbados/dat-boi/issues/13) so I looked into the discovery-channel code included in the stacktrace. The change of `(--pending <= 0)` to `(--pending <= 1)` seemed to fix it on my end but I'm not entirely sure why.

It seemed like if pending ever rose to or above 2, then one callback could succeed while a second callback would  bypass the check for `firstQueryDone`, thus calling the callback multiple times. As you see in the function `ready`, pending can easily become 2 if it has truthy dns and dht values.

This is a WIP solution in search of something more robust.