### PR TITLE
destroy() is not a method on list() output items

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,6 @@ Discovery.prototype.leave = function (id, port) {
 Discovery.prototype.update = function () {
   var all = this.list()
   for (var i = 0; i < all.length; i++) {
-    all[i].destroy()
     this.leave(all[i].id, all[i].port)
     this.join(all[i].id, all[i].port)
   }


### PR DESCRIPTION
Calling channel.update() fails since list() items don't have that method. Not sure if something else is required in its place.